### PR TITLE
Remove cdn.cookielaw.org

### DIFF
--- a/dns
+++ b/dns
@@ -503,7 +503,6 @@ cdn.clickiocdn.com
 cdn.cloudimagesb.com
 cdn.confiant-integrations.net
 cdn.convertbox.com
-cdn.cookielaw.org
 cdn.dataroid.com
 cdn.dimml.io
 cdn.dokondigit.quest


### PR DESCRIPTION
Since cdn.cookielaw.org is blocked, OneTrust can not load. OneTrust is used to orchestrate data deletion across all 3rd party services that a company uses,  which is desired.

It _can_ be used to orchestrate loading other scripts like google tag manager, google analytics, etc, and other things that would want to be blocked, but those should all be explicitly blocked themselves.

If anything maybe consider allowing the `cdn.cookielaw.org/scripttemplates/otSDKStub.js` and keep the
 `cdn.cookielaw.org/scripttemplates/*/BannerSDK.js` and `cdn.cookielaw.org/scripttemplates/*/assets/*` blocked?